### PR TITLE
Properly parsing transferLock param in resource_domain.go

### DIFF
--- a/inwx/internal/resource/resource_domain.go
+++ b/inwx/internal/resource/resource_domain.go
@@ -199,7 +199,7 @@ func resourceDomainRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.Set("nameservers", resData["ns"])
 	d.Set("period", resData["period"])
 	d.Set("renewal_mode", resData["renewalMode"])
-	d.Set("transfer_lock", resData["transferLock"] == 1.0) // convert 1.0 to true. Must be a float!
+	d.Set("transfer_lock", resData["transferLock"])
 
 	contacts := map[string]interface{}{}
 	contacts["registrant"] = int(resData["registrant"].(float64))


### PR DESCRIPTION
The "domain.info" method of the INWX JsonRPC API returns a boolean for the property transferLock. The provider expects a float for some reason. Maybe that was a bug in the API that INWX already has fixed. The type for this property can be confirmed at https://www.inwx.com/en/help/apidoc/f/ch02s09.html#domain.info.  I have tested it myself and it is indeed a boolean.