### PR TITLE
Read whois_protection in resource_domain_contact.go

### DIFF
--- a/inwx/internal/resource/resource_domain_contact.go
+++ b/inwx/internal/resource/resource_domain_contact.go
@@ -262,6 +262,7 @@ func resourceContactRead(ctx context.Context, data *schema.ResourceData, meta in
 		data.Set("fax", contact.FaxNumber)
 	}
 	data.Set("email", contact.Email)
+	data.Set("whois_protection", contact.WhoisProtection)
 	if contact.Remarks != "" {
 		data.Set("remarks", contact.Remarks)
 	}


### PR DESCRIPTION
It seems someone forgot add a line to read the "protection" property of the "contact.info" response.