### PR TITLE
Fix matching of records and read of the "name" property

### DIFF
--- a/inwx/internal/resource/resource_nameserver_record.go
+++ b/inwx/internal/resource/resource_nameserver_record.go
@@ -265,11 +265,14 @@ func resourceNameserverRecordRead(ctx context.Context, d *schema.ResourceData, m
 	for _, record := range records {
 		recordt := record.(map[string]any)
 
-		if recordt["name"].(string)+":"+strconv.Itoa(int(recordt["id"].(float64))) == d.Id() {
-			d.Set("domain", recordt["name"].(string))
+		if d.Get("domain").(string)+":"+strconv.Itoa(int(recordt["id"].(float64))) == d.Id() {
+			d.Set("domain", d.Get("domain").(string))
 			d.Set("type", recordt["type"].(string))
 			d.Set("content", recordt["content"].(string))
 
+			if val, ok := recordt["name"]; ok {
+				d.Set("name", val.(string))
+			}
 			if val, ok := recordt["urlRedirectType"]; ok {
 				d.Set("url_redirect_type", val.(string))
 			}


### PR DESCRIPTION
The identifier of inwx_nameserver_record resources is: DOMAIN_NAME:RO_ID, but what was implemented was RECORD_NAME:RO_ID. That made impossible to use the terraform import command and blocks (v1.5+).  Also, the value of the record's "name" property was stored in the state as the property "domain". That was fixed as well.