### PR TITLE
Fix deletes & updates breaking on "unexpected end of JSON input"

### DIFF
--- a/inwx/internal/resource/resource_nameserver_record.go
+++ b/inwx/internal/resource/resource_nameserver_record.go
@@ -365,20 +365,12 @@ func resourceNameserverRecordUpdate(ctx context.Context, d *schema.ResourceData,
 		parameters["testing"] = testing
 	}
 
-	call, err := client.Call(ctx, "nameserver.updateRecord", parameters)
+	err = client.CallNoResponseBody(ctx, "nameserver.updateRecord", parameters)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not update nameserver record",
 			Detail:   err.Error(),
-		})
-		return diags
-	}
-	if call.Code() != api.COMMAND_SUCCESSFUL {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Could not update nameserver record",
-			Detail:   fmt.Sprintf("API response not status code 1000. Got response: %s", call.ApiError()),
 		})
 		return diags
 	}
@@ -408,20 +400,12 @@ func resourceNameserverRecordDelete(ctx context.Context, d *schema.ResourceData,
 		parameters["testing"] = testing
 	}
 
-	call, err := client.Call(ctx, "nameserver.deleteRecord", parameters)
+	err = client.CallNoResponseBody(ctx, "nameserver.deleteRecord", parameters)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not delete nameserver record",
 			Detail:   err.Error(),
-		})
-		return diags
-	}
-	if call.Code() != api.COMMAND_SUCCESSFUL && call.Code() != api.COMMAND_SUCCESSFUL_PENDING {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Error,
-			Summary:  "Could not delete nameserver record",
-			Detail:   fmt.Sprintf("API response not status code 1000 pr 1001. Got response: %s", call.ApiError()),
 		})
 		return diags
 	}


### PR DESCRIPTION
Call is always attempting to parse response body, which leads to errors in case
of no-response calls such as nameserver.deleteRecord.

In order to allow for such without breaking our API, let's:
* rename the original Call into _Call
* introduce a boolean of `expectResponseBody` into _Call
* offer a new Call that keeps the stable interface, but translates into _Call(..., true)
* offer a new CallNoResponseBody that can be used by such no-response calls

Then,

Use the new `client.CallNoResponseBody` instead of client.Call and avoid erroring
on body failing to parse in NameserverRecordUpdate & NameserverRecordDelete.


Fixes #12 