### PR TITLE
Feat: enhance nameserver resource import, add update support - Fixes Issue #37

### DIFF
--- a/inwx/internal/resource/resource_domain_contact.go
+++ b/inwx/internal/resource/resource_domain_contact.go
@@ -3,28 +3,29 @@ package resource
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/inwx/terraform-provider-inwx/inwx/internal/api"
-	"reflect"
-	"strconv"
-	"strings"
 )
 
 type Contact struct {
-	Type            string
-	Name            string
-	Organization    string
-	StreetAddress   string
-	City            string
-	PostalCode      string
-	StateProvince   string
-	CountryCode     string
-	PhoneNumber     string
-	FaxNumber       string
-	Email           string
-	Remarks         string
+	Type          string
+	Name          string
+	Organization  string
+	StreetAddress string
+	City          string
+	PostalCode    string
+	StateProvince string
+	CountryCode   string
+	PhoneNumber   string
+	FaxNumber     string
+	Email         string
+	Remarks       string
 }
 
 func DomainContactResource() *schema.Resource {
@@ -144,15 +145,15 @@ func resourceContactCreate(ctx context.Context, data *schema.ResourceData, meta 
 	contact := expandContactFromResourceData(data)
 
 	parameters := map[string]interface{}{
-		"type":       contact.Type,
-		"name":       contact.Name,
-		"street":     contact.StreetAddress,
-		"city":       contact.City,
-		"pc":         contact.PostalCode,
-		"sp":         contact.StateProvince,
-		"cc":         contact.CountryCode,
-		"voice":      contact.PhoneNumber,
-		"email":      contact.Email,
+		"type":   contact.Type,
+		"name":   contact.Name,
+		"street": contact.StreetAddress,
+		"city":   contact.City,
+		"pc":     contact.PostalCode,
+		"sp":     contact.StateProvince,
+		"cc":     contact.CountryCode,
+		"voice":  contact.PhoneNumber,
+		"email":  contact.Email,
 	}
 	if contact.Organization != "" {
 		parameters["org"] = contact.Organization
@@ -187,13 +188,13 @@ func resourceContactCreate(ctx context.Context, data *schema.ResourceData, meta 
 	}
 
 	rawId := call["resData"].(map[string]interface{})["id"]
-	switch rawId.(type) {
+	switch id := rawId.(type) {
 	case string:
 		// When contact already exists: id = string
-		data.SetId(rawId.(string))
+		data.SetId(id)
 	case float64:
 		// When contact does not already exist: id = float64 ...
-		data.SetId(strconv.Itoa(int(rawId.(float64))))
+		data.SetId(strconv.Itoa(int(id)))
 	default:
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -396,18 +397,18 @@ func expandContactFromResourceData(data *schema.ResourceData) *Contact {
 	}
 
 	return &Contact{
-		Type:            data.Get("type").(string),
-		Name:            data.Get("name").(string),
-		Organization:    organization,
-		StreetAddress:   data.Get("street_address").(string),
-		City:            data.Get("city").(string),
-		PostalCode:      data.Get("postal_code").(string),
-		StateProvince:   stateProvince,
-		CountryCode:     data.Get("country_code").(string),
-		PhoneNumber:     data.Get("phone_number").(string),
-		FaxNumber:       fax,
-		Email:           data.Get("email").(string),
-		Remarks:         remarks,
+		Type:          data.Get("type").(string),
+		Name:          data.Get("name").(string),
+		Organization:  organization,
+		StreetAddress: data.Get("street_address").(string),
+		City:          data.Get("city").(string),
+		PostalCode:    data.Get("postal_code").(string),
+		StateProvince: stateProvince,
+		CountryCode:   data.Get("country_code").(string),
+		PhoneNumber:   data.Get("phone_number").(string),
+		FaxNumber:     fax,
+		Email:         data.Get("email").(string),
+		Remarks:       remarks,
 	}
 }
 
@@ -430,17 +431,17 @@ func expandContactFromInfoResponse(contactData map[string]interface{}) *Contact 
 	}
 
 	return &Contact{
-		Type:            contactData["type"].(string),
-		Name:            contactData["name"].(string),
-		Organization:    organization,
-		StreetAddress:   contactData["street"].(string),
-		City:            contactData["city"].(string),
-		PostalCode:      contactData["pc"].(string),
-		StateProvince:   stateProvince,
-		CountryCode:     contactData["cc"].(string),
-		PhoneNumber:     contactData["voice"].(string),
-		FaxNumber:       fax,
-		Email:           contactData["email"].(string),
-		Remarks:         remarks,
+		Type:          contactData["type"].(string),
+		Name:          contactData["name"].(string),
+		Organization:  organization,
+		StreetAddress: contactData["street"].(string),
+		City:          contactData["city"].(string),
+		PostalCode:    contactData["pc"].(string),
+		StateProvince: stateProvince,
+		CountryCode:   contactData["cc"].(string),
+		PhoneNumber:   contactData["voice"].(string),
+		FaxNumber:     fax,
+		Email:         contactData["email"].(string),
+		Remarks:       remarks,
 	}
 }

--- a/inwx/internal/resource/resource_nameserver.go
+++ b/inwx/internal/resource/resource_nameserver.go
@@ -3,12 +3,15 @@ package resource
 import (
 	"context"
 	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/inwx/terraform-provider-inwx/inwx/internal/api"
-	"strconv"
-	"strings"
 )
 
 func resourceNameserverParseId(id string) (string, string, error) {
@@ -33,11 +36,11 @@ func NameserverResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceNameserverCreate,
 		ReadContext:   resourceNameserverRead,
+		UpdateContext: resourceNameserverUpdate,
 		DeleteContext: resourceNameserverDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, i interface{}) ([]*schema.ResourceData, error) {
 				domain, id, err := resourceNameserverParseId(d.Id())
-
 				if err != nil {
 					return nil, err
 				}
@@ -47,6 +50,49 @@ func NameserverResource() *schema.Resource {
 					return nil, err
 				}
 				d.SetId(fmt.Sprintf("%s:%s", domain, id))
+
+				// API nameserver.info doesn't return nameservers and soa_mail
+				// so we need to read them from environment variables for a successful import
+				//
+				// Example:
+				// 	INWX_NAMESERVERS="ns1.example.com,ns2.example.com,ns3.example.com"
+				// 	INWX_SOA_MAIL="admin@example.com"
+
+				// Read nameservers from environment variable (comma-separated list)
+				if nsEnv := os.Getenv("INWX_NAMESERVERS"); nsEnv != "" {
+					nameservers := strings.Split(nsEnv, ",")
+					// Convert to []interface{} as required by TypeList
+					nsInterface := make([]interface{}, len(nameservers))
+					for i, ns := range nameservers {
+						ns = strings.TrimSpace(ns)
+						// Validate each nameserver
+						if err := validateFQDN(ns); err != nil {
+							return nil, fmt.Errorf("invalid nameserver '%s': %w", ns, err)
+						}
+						nsInterface[i] = ns
+					}
+					if err := d.Set("nameservers", nsInterface); err != nil {
+						return nil, fmt.Errorf("error setting nameservers: %s", err)
+					}
+				}
+
+				// Read soa_mail from environment variable
+				if soaMail := os.Getenv("INWX_SOA_MAIL"); soaMail != "" {
+					soaMail = strings.TrimSpace(soaMail)
+					// Validate email address
+					if err := validateEmail(soaMail); err != nil {
+						return nil, fmt.Errorf("invalid SOA mail: %w", err)
+					}
+					if err := d.Set("soa_mail", soaMail); err != nil {
+						return nil, fmt.Errorf("error setting soa_mail: %s", err)
+					}
+				}
+
+				// Call read to get the rest of the data
+				diags := resourceNameserverRead(ctx, d, i)
+				if diags.HasError() {
+					return nil, fmt.Errorf("failed to read nameserver data: %v", diags[0].Summary)
+				}
 
 				return []*schema.ResourceData{d}, nil
 			},
@@ -78,7 +124,7 @@ func NameserverResource() *schema.Resource {
 					})
 					return diags
 				},
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"nameservers": {
 				Description: "List of nameservers",
@@ -87,25 +133,25 @@ func NameserverResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 				Required: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"master_ip": {
 				Description: "Master IP address",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"web": {
 				Description: "Web nameserver entry",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"mail": {
 				Description: "Mail nameserver entry",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"soa_mail": {
 				Description: "Email address for SOA record",
@@ -133,38 +179,38 @@ func NameserverResource() *schema.Resource {
 					})
 					return diags
 				},
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"url_redirect_title": {
 				Description: "Title of the frame redirection",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"url_redirect_description": {
 				Description: "Description of the frame redirection",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"url_redirect_fav_icon": {
 				Description: "FavIcon of the frame redirection",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"url_redirect_keywords": {
 				Description: "Keywords of the frame redirection",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"testing": {
 				Description: "Execute command in testing mode",
 				Type:        schema.TypeBool,
 				Required:    false,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 			},
 			"ignore_existing": {
 				Description: "Ignore existing",
@@ -176,17 +222,14 @@ func NameserverResource() *schema.Resource {
 	}
 }
 
-func resourceNameserverCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
-	client := m.(*api.Client)
-
-	domain := d.Get("domain").(string)
-
+// buildNameserverParameters builds the common parameter map used by both create and update operations
+func buildNameserverParameters(d *schema.ResourceData) map[string]interface{} {
 	parameters := map[string]interface{}{
-		"domain": domain,
+		"domain": d.Get("domain").(string),
 		"type":   d.Get("type").(string),
 	}
 
+	// Add optional parameters if they exist
 	if ns, ok := d.GetOk("nameservers"); ok {
 		parameters["ns"] = ns
 	}
@@ -217,15 +260,35 @@ func resourceNameserverCreate(ctx context.Context, d *schema.ResourceData, m int
 	if testing, ok := d.GetOk("testing"); ok {
 		parameters["testing"] = testing
 	}
-	if ignoreExisting, ok := d.GetOk("ignore_existing"); ok {
-		parameters["ignoreExisting"] = ignoreExisting
+
+	return parameters
+}
+
+// createOrUpdateNameserver handles both create and update operations
+func createOrUpdateNameserver(ctx context.Context, d *schema.ResourceData, m interface{}, isCreate bool) diag.Diagnostics {
+	var diags diag.Diagnostics
+	client := m.(*api.Client)
+
+	parameters := buildNameserverParameters(d)
+
+	// Add create-specific parameters
+	if isCreate {
+		if ignoreExisting, ok := d.GetOk("ignore_existing"); ok {
+			parameters["ignoreExisting"] = ignoreExisting
+		}
 	}
 
-	call, err := client.Call(ctx, "nameserver.create", parameters)
+	// Determine the API endpoint
+	endpoint := "nameserver.update"
+	if isCreate {
+		endpoint = "nameserver.create"
+	}
+
+	call, err := client.Call(ctx, endpoint, parameters)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Could not add nameserver record",
+			Summary:  fmt.Sprintf("Could not %s nameserver record", map[bool]string{true: "add", false: "update"}[isCreate]),
 			Detail:   err.Error(),
 		})
 		return diags
@@ -233,19 +296,24 @@ func resourceNameserverCreate(ctx context.Context, d *schema.ResourceData, m int
 	if call.Code() != api.COMMAND_SUCCESSFUL && call.Code() != api.COMMAND_SUCCESSFUL_PENDING {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Could not add nameserver record",
+			Summary:  fmt.Sprintf("Could not %s nameserver record", map[bool]string{true: "add", false: "update"}[isCreate]),
 			Detail:   fmt.Sprintf("API response not status code 1000 or 1001. Got response: %s", call.ApiError()),
 		})
 		return diags
 	}
 
-	resData := call["resData"].(map[string]any)
+	// Set the ID for newly created resources
+	if isCreate {
+		resData := call["resData"].(map[string]any)
+		d.SetId(d.Get("domain").(string) + ":" + strconv.Itoa(int(resData["roId"].(float64))))
+	}
 
-	d.SetId(domain + ":" + strconv.Itoa(int(resData["roId"].(float64))))
+	// Read the resource to ensure the Terraform state is up to date
+	return resourceNameserverRead(ctx, d, m)
+}
 
-	resourceNameserverRecordRead(ctx, d, m)
-
-	return diags
+func resourceNameserverCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return createOrUpdateNameserver(ctx, d, m, true)
 }
 
 func resourceNameserverRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -264,28 +332,23 @@ func resourceNameserverRead(ctx context.Context, d *schema.ResourceData, m inter
 	if resData, ok := call["resData"]; ok {
 		resData := resData.(map[string]any)
 
-		if val, ok := resData["domain"]; ok {
-			err := d.Set("domain", val.(string))
-			if err != nil {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Error,
-					Summary:  "Could not set domain name",
-					Detail:   fmt.Sprintf("Expected domain name. %s", err.Error()),
-				})
-				return diags
+		// Helper function to safely set values
+		setValue := func(key string, field string) {
+			if val, ok := resData[key]; ok {
+				err := d.Set(field, val)
+				if err != nil {
+					diags = append(diags, diag.Diagnostic{
+						Severity: diag.Error,
+						Summary:  fmt.Sprintf("Could not set %s", field),
+						Detail:   fmt.Sprintf("Expected %s. %s", field, err.Error()),
+					})
+				}
 			}
 		}
-		if val, ok := resData["type"]; ok {
-			err := d.Set("type", val.(string))
-			if err != nil {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Error,
-					Summary:  "Could not set type",
-					Detail:   fmt.Sprintf("Expected type. %s", err.Error()),
-				})
-				return diags
-			}
-		}
+
+		setValue("domain", "domain")
+		setValue("type", "type")
+		setValue("masterIp", "master_ip")
 	}
 
 	return diags
@@ -314,4 +377,49 @@ func resourceNameserverDelete(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	return diags
+}
+
+func resourceNameserverUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return createOrUpdateNameserver(ctx, d, m, false)
+}
+
+// validateFQDN checks if a string is a valid Fully Qualified Domain Name
+func validateFQDN(fqdn string) error {
+	// Remove trailing dot if present
+	fqdn = strings.TrimSuffix(fqdn, ".")
+
+	// FQDN must not be longer than 255 characters
+	if len(fqdn) > 255 {
+		return fmt.Errorf("FQDN '%s' is too long (max 255 characters)", fqdn)
+	}
+
+	// Split into labels
+	labels := strings.Split(fqdn, ".")
+
+	// Must have at least two labels
+	if len(labels) < 2 {
+		return fmt.Errorf("FQDN '%s' must have at least two parts separated by dots", fqdn)
+	}
+
+	// Validate each label
+	for _, label := range labels {
+		if len(label) == 0 || len(label) > 63 {
+			return fmt.Errorf("FQDN label '%s' must be between 1 and 63 characters", label)
+		}
+		if !regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$`).MatchString(label) {
+			return fmt.Errorf("FQDN label '%s' contains invalid characters", label)
+		}
+	}
+
+	return nil
+}
+
+// validateEmail checks if a string is a valid email address
+func validateEmail(email string) error {
+	// Basic email regex pattern
+	emailRegex := regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+	if !emailRegex.MatchString(email) {
+		return fmt.Errorf("invalid email address format: %s", email)
+	}
+	return nil
 }


### PR DESCRIPTION
Fixes: https://github.com/inwx/terraform-provider-inwx/issues/37

- Add UpdateContext to nameserver resource
- Remove ForceNew from most resource attributes
- Implement createOrUpdateNameserver function to handle both create and update
- Add import validation with environment variable support for nameservers and SOA mail
- Implement FQDN and email validation helpers
- Improve error handling and resource state management

`terraform import` / `tofu import` usage:

API nameserver.info doesn't return `nameservers` and `soa_mail`, which are required to import a nameserver resource without triggering a force replacement. So, we need to read them from environment variables for a successful import. I don't see another reasonable way to inject this additional information and avoid resource replacement.

Example:
```
INWX_NAMESERVERS="ns1.example.com,ns2.example.com,ns3.example.com"
INWX_SOA_MAIL="admin@example.com"
tofu import inwx_nameserver.tld example.com:12345
```

This PR also contains a minor improvement in `inwx/internal/resource/resource_domain_contact.go` to satisfy go lint 
- refactor: improve code formatting and type handling in domain contact resource