### PR TITLE
chore(docs): add OpenTofu support in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 INWX Terraform Provider
 =========
 
-INWX Terraform Provider is a plugin for Terraform that allows registration and management of domains and their domain contacts. This plugin is on Terraform Registry: https://registry.terraform.io/providers/inwx/inwx
+INWX Terraform Provider is a plugin for Terraform/OpenTofu that allows registration and management of domains and their domain contacts. This plugin is on Terraform Registry: https://registry.terraform.io/providers/inwx/inwx
 
 Documentation
 ------


### PR DESCRIPTION
Updated the README to highlight compatibility with Terraform/OpenTofu. This ensures users are aware that the plugin supports both platforms for domain management. No functional changes were made to the plugin itself.