### PR TITLE
feat: fix record types

### DIFF
--- a/docs/resources/inwx_domain.md
+++ b/docs/resources/inwx_domain.md
@@ -83,6 +83,9 @@ resource "inwx_domain" "example_com" {
 
 ### Nested Fields
 
+Depending on the TLD, the following can be optional and will thus not be shown in the api after creation.
+Registrant will always be required.
+
 `contacts`
 * `registrant` - (Required) Id of the registrant contact
 * `admin` - (Required) Id of the admin contact

--- a/docs/resources/inwx_domain_contact.md
+++ b/docs/resources/inwx_domain_contact.md
@@ -26,7 +26,7 @@ resource "inwx_domain_contact" "example_person" {
 * `street_address` - (Required) Street Address of the contact
 * `city` - (Required) City of the contact
 * `postal_code` - (Required) Postal Code/Zipcode of the contact
-* `state_province` - (Optional) State/Province name of the contact
+* `state_province` - (Optional) State/Province name of the contact. Required for certain TLDs
 * `country_code` - (Required) Country code of the contact. Must be two characters
 * `phone_number` - (Required) Phone number of the contact
 * `fax` - (Optional) Fax number of the contact

--- a/docs/resources/inwx_nameserver_record.md
+++ b/docs/resources/inwx_nameserver_record.md
@@ -16,7 +16,7 @@ resource "inwx_nameserver_record" "example_com_txt_1" {
 
 * `domain` - (Required) Name of the domain
 * `type` - (Required) Type of the nameserver record. One of: `A`, `AAAA`, `AFSDB`, `ALIAS`, `CAA`, `CERT`, `CNAME`, 
-`HINFO`, `KEY`, `LOC`, `MX`, `NAPTR`, `NS`, `OPENPGPKEY`, `PTR`, `RP`, `SMIMEA`, `SOA`, `SRV`, `SSHFP`, `TLSA`, `TXT`, 
+`HINFO`, `LOC`, `MX`, `NAPTR`, `NS`, `OPENPGPKEY`, `PTR`, `RP`, `SMIMEA`, `SOA`, `SRV`, `SSHFP`, `TLSA`, `TXT`, 
 `URI`, `URL`
 * `ro_id` - (Optional) DNS domain id
 * `content` - (Required) Content of the nameserver record

--- a/docs/resources/inwx_nameserver_record.md
+++ b/docs/resources/inwx_nameserver_record.md
@@ -16,7 +16,7 @@ resource "inwx_nameserver_record" "example_com_txt_1" {
 
 * `domain` - (Required) Name of the domain
 * `type` - (Required) Type of the nameserver record. One of: `A`, `AAAA`, `AFSDB`, `ALIAS`, `CAA`, `CERT`, `CNAME`, 
-`HINFO`, `LOC`, `MX`, `NAPTR`, `NS`, `OPENPGPKEY`, `PTR`, `RP`, `SMIMEA`, `SOA`, `SRV`, `SSHFP`, `TLSA`, `TXT`, 
+`HINFO`, `HTTPS`, `IPSECKEY`, `LOC`, `MX`, `NAPTR`, `NS`, `OPENPGPKEY`, `PTR`, `RP`, `SMIMEA`, `SOA`, `SRV`, `SSHFP`, `SVCB`, `TLSA`, `TXT`, 
 `URI`, `URL`
 * `ro_id` - (Optional) DNS domain id
 * `content` - (Required) Content of the nameserver record

--- a/inwx/internal/resource/resource_nameserver_record.go
+++ b/inwx/internal/resource/resource_nameserver_record.go
@@ -3,13 +3,14 @@ package resource
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/inwx/terraform-provider-inwx/inwx/internal/api"
-	"strconv"
-	"strings"
 )
 
 func resourceNameserverRecordParseId(id string) (string, string, error) {
@@ -24,7 +25,7 @@ func resourceNameserverRecordParseId(id string) (string, string, error) {
 
 func NameserverRecordResource() *schema.Resource {
 	validRecordTypes := []string{
-		"A", "AAAA", "AFSDB", "ALIAS", "CAA", "CERT", "CNAME", "HINFO", "KEY", "LOC", "MX", "NAPTR", "NS", "OPENPGPKEY",
+		"A", "AAAA", "AFSDB", "ALIAS", "CAA", "CERT", "CNAME", "HINFO", "LOC", "MX", "NAPTR", "NS", "OPENPGPKEY",
 		"PTR", "RP", "SMIMEA", "SOA", "SRV", "SSHFP", "TLSA", "TXT", "URI", "URL",
 	}
 

--- a/inwx/internal/resource/resource_nameserver_record.go
+++ b/inwx/internal/resource/resource_nameserver_record.go
@@ -25,8 +25,8 @@ func resourceNameserverRecordParseId(id string) (string, string, error) {
 
 func NameserverRecordResource() *schema.Resource {
 	validRecordTypes := []string{
-		"A", "AAAA", "AFSDB", "ALIAS", "CAA", "CERT", "CNAME", "HINFO", "LOC", "MX", "NAPTR", "NS", "OPENPGPKEY",
-		"PTR", "RP", "SMIMEA", "SOA", "SRV", "SSHFP", "TLSA", "TXT", "URI", "URL",
+		"A", "AAAA", "AFSDB", "ALIAS", "CAA", "CERT", "CNAME", "HINFO", "HTTPS", "IPSECKEY", "LOC", "MX", "NAPTR", "NS", "OPENPGPKEY",
+		"PTR", "RP", "SMIMEA", "SOA", "SRV", "SSHFP", "SVCB", "TLSA", "TXT", "URI", "URL",
 	}
 
 	validUrlRedirectTypes := []string{


### PR DESCRIPTION
- **fix(resource): remove deprecated record type KEY from schema**
- **docs(resource): clarify `state_province` requirement for TLDs**
- **feat(resource): add SVCB, IPSECKEY and HTTPS record types**
- **docs(resource): clarify optional fields for TLDs**
