### PR TITLE
chore: remove unused vars

### DIFF
--- a/inwx/internal/api/client.go
+++ b/inwx/internal/api/client.go
@@ -17,8 +17,6 @@ import (
 
 var (
 	version = "dev"
-	commit  = "none"
-	date    = "unknown"
 )
 
 const (

--- a/inwx/internal/api/client.go
+++ b/inwx/internal/api/client.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-logr/logr"
-	cookiejar "github.com/orirawlings/persistent-cookiejar"
-	"github.com/pkg/errors"
 	"net/http"
 	"net/url"
 	"os"
 	"runtime"
 	"sync"
+
+	"github.com/go-logr/logr"
+	cookiejar "github.com/orirawlings/persistent-cookiejar"
+	"github.com/pkg/errors"
 )
 
 var (


### PR DESCRIPTION
I found some, most likely, unused variables in the inwx/internal/api package.