### PR TITLE
fix: sprintf err

### DIFF
--- a/inwx/internal/api/client.go
+++ b/inwx/internal/api/client.go
@@ -35,7 +35,7 @@ func (r Response) Code() float64 {
 func (r Response) ApiError() string {
 	jsonStr, err := json.Marshal(r)
 	if err != nil {
-		return fmt.Sprintf("could not parse error: %w", err)
+		return fmt.Sprintf("could not parse error: %v", err)
 	}
 	return string(jsonStr)
 }

--- a/inwx/internal/api/client.go
+++ b/inwx/internal/api/client.go
@@ -5,14 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/go-logr/logr"
-	cookiejar "github.com/orirawlings/persistent-cookiejar"
-	"github.com/pkg/errors"
 	"net/http"
 	"net/url"
 	"os"
 	"runtime"
 	"sync"
+
+	"github.com/go-logr/logr"
+	cookiejar "github.com/orirawlings/persistent-cookiejar"
+	"github.com/pkg/errors"
 )
 
 var (

--- a/inwx/provider.go
+++ b/inwx/provider.go
@@ -72,7 +72,7 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not configure context",
-			Detail:   fmt.Sprintf("Could not parse api_url: %w", err),
+			Detail:   fmt.Sprintf("Could not parse api_url: %v", err),
 		})
 		return nil, diags
 	}
@@ -83,7 +83,7 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not configure context",
-			Detail:   fmt.Sprintf("Could not create http client: %w", err),
+			Detail:   fmt.Sprintf("Could not create http client: %v", err),
 		})
 		return nil, diags
 	}
@@ -97,7 +97,7 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Could not configure context",
-			Detail:   fmt.Sprintf("Could not authenticate at api via account.login: %w", err),
+			Detail:   fmt.Sprintf("Could not authenticate at api via account.login: %v", err),
 		})
 		return nil, diags
 	}
@@ -121,7 +121,7 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  "Could not unlock account",
-				Detail:   fmt.Sprintf("Could not authenticate at api via account.unlock: %w", err),
+				Detail:   fmt.Sprintf("Could not authenticate at api via account.unlock: %v", err),
 			})
 			return nil, diags
 		}

--- a/inwx/provider.go
+++ b/inwx/provider.go
@@ -3,8 +3,9 @@ package inwx
 import (
 	"context"
 	"fmt"
-	"github.com/inwx/terraform-provider-inwx/inwx/internal/data_source"
 	"net/url"
+
+	"github.com/inwx/terraform-provider-inwx/inwx/internal/data_source"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"


### PR DESCRIPTION
replace %w on fmt.Sprintf() with %v
    
%w is not valid for fmt.Sprintf(), only for fmt.Errorf().
    
```
printf: fmt.Sprintf does not support error-wrapping directive %w
```