### PR TITLE
fix(resource): handle nil fields in dnssec.info response

### DIFF
--- a/inwx/internal/resource/resource_automated_dnssec.go
+++ b/inwx/internal/resource/resource_automated_dnssec.go
@@ -83,7 +83,12 @@ func resourceAutomatedDNSSECRead(ctx context.Context, d *schema.ResourceData, m 
 			continue
 		}
 
-		if domainInfo["domain"].(string) == domain && domainInfo["dnssecStatus"].(string) == "AUTO" {
+		domainStr, ok1 := domainInfo["domain"].(string)
+		dnssecStatus, ok2 := domainInfo["dnssecStatus"].(string)
+		if !ok1 || !ok2 {
+			continue
+		}
+		if domainStr == domain && dnssecStatus == "AUTO" {
 			d.SetId(domain)
 			found = true
 			break


### PR DESCRIPTION
## Problem

Importing an existing `inwx_automated_dnssec` resource crashes the provider during the post-import read phase:

```
panic: interface conversion: interface {} is nil, not string
```

## Cause

`resourceAutomatedDNSSECRead` performs direct type assertions on fields from the `dnssec.info` API response:

```go
if domainInfo["domain"].(string) == domain && domainInfo["dnssecStatus"].(string) == "AUTO" {
```

If either field is absent or `nil` in the returned map entry — which can occur for domains in certain states — the assertion panics. After `terraform import`, the provider performs an immediate state refresh that hits this path without prior state to filter on.

## Fix

Replace the direct assertions with safe two-value assertions and skip entries where either field is not a non-nil string:

```go
domainStr, ok1 := domainInfo["domain"].(string)
dnssecStatus, ok2 := domainInfo["dnssecStatus"].(string)
if !ok1 || !ok2 {
    continue
}
if domainStr == domain && dnssecStatus == "AUTO" {
```

This matches the pattern used in other resources in this provider (e.g., `resource_nameserver.go`).

## Behavior

- Import + subsequent read no longer panics on nil/missing fields
- Entries with incomplete API data are skipped gracefully
- Existing behavior for complete API responses is unchanged

## Testing

Verified against the live INWX API using a domain with automated DNSSEC active:

1. `tofu state rm inwx_automated_dnssec.domain` — removed resource from state
2. `tofu import inwx_automated_dnssec.domain luciano.de` — import + post-import read completed without panic
3. `tofu plan` — subsequent refresh stable, no diff

The provider was built from this branch and loaded via `dev_overrides`. No test files exist in this repository.

Fixes #72.